### PR TITLE
feat: implement logout

### DIFF
--- a/app/components/layouts/MainLayout.tsx
+++ b/app/components/layouts/MainLayout.tsx
@@ -18,12 +18,12 @@ interface MainLayoutProps {
 }
 
 const MainLayout: FC<MainLayoutProps> = ({ children }) => {
-	const navigate = useNavigate();
-	if (!getToken()) {
-		navigate('/auth/login');
-	} else {
-		navigate('/general');
-	}
+	// const navigate = useNavigate();
+	// if (!getToken()) {
+	// 	navigate('/auth/login');
+	// } else {
+	// 	navigate('/general');
+	// }
 	return (
 		<div className='main-layout'>
 			<Navbar />

--- a/app/components/sidebar/Sidebar.tsx
+++ b/app/components/sidebar/Sidebar.tsx
@@ -6,7 +6,6 @@ const sectionsByRole: Record<string, { name: string; path: string }[]> = {
 	admin: [
 		{ name: 'Inicio', path: '/general' },
 		{ name: 'Historial Préstamos', path: '/prestamo' },
-		{ name: 'Historial Devoluciones', path: '/admin/returns' },
 		{ name: 'Gestionar Libros', path: '/books' },
 		{ name: 'Soporte', path: '/admin/support' },
 		{ name: 'Salir', path: '/logout' },

--- a/app/routes/logout/route.tsx
+++ b/app/routes/logout/route.tsx
@@ -1,0 +1,27 @@
+import cookies from 'js-cookie';
+import { useNavigate } from '@remix-run/react';
+import { useEffect } from 'react';
+
+const getToken = () => {
+	const token = cookies.get('$$id');
+	if (!token) {
+		return null;
+	}
+	return token;
+};
+
+function Logout() {
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		const token = getToken();
+		if (token) {
+			cookies.remove('$$id');
+			navigate('/auth/login');
+		}
+	}, [navigate]);
+
+	return null;
+}
+
+export default Logout;


### PR DESCRIPTION
This pull request includes several changes to the authentication and navigation flow, as well as updates to the sidebar menu. The most important changes involve commenting out the navigation logic in the `MainLayout`, removing a sidebar menu item, and adding a new logout route.

### Authentication and Navigation Updates:
* [`app/components/layouts/MainLayout.tsx`](diffhunk://#diff-ca6cbe00b240989290c99f59134dc03938670eeb92652aa4b842921be6881a26L21-R26): Commented out the navigation logic that redirects users based on the presence of a token.
* [`app/routes/logout/route.tsx`](diffhunk://#diff-01a8f1c6a0b3af889010b113a1d7a2b80271d9b8fab23403fb521e9f3c6b1b80R1-R27): Added a new `Logout` component that removes the authentication token and navigates to the login page.

### Sidebar Menu Updates:
* [`app/components/sidebar/Sidebar.tsx`](diffhunk://#diff-90c7b507ad9b9a2dd9c70959d29f6bf0d3ec82b39a60723b7115fb1f9bb58929L9): Removed the "Historial Devoluciones" item from the admin section of the sidebar menu.